### PR TITLE
allwinner: Add BL32(corresponds to Trusted OS) support

### DIFF
--- a/plat/allwinner/common/include/platform_def.h
+++ b/plat/allwinner/common/include/platform_def.h
@@ -39,4 +39,13 @@
 #define PLATFORM_MMAP_REGIONS		4
 #define PLATFORM_STACK_SIZE		(0x1000 / PLATFORM_CORE_COUNT)
 
+#define PLAT_ARM_NS_IMAGE_OFFSET    0x4a000000
+
+#ifdef SPD_opteed
+#define BL32_BASE                   SUNXI_DRAM_BASE
+#endif
+#ifdef SPD_none
+#undef BL32_BASE
+#endif
+
 #endif /* __PLATFORM_DEF_H__ */

--- a/plat/allwinner/common/sunxi_bl31_setup.c
+++ b/plat/allwinner/common/sunxi_bl31_setup.c
@@ -12,11 +12,13 @@
 #include <gicv2.h>
 #include <platform.h>
 #include <platform_def.h>
+#include <plat_arm.h>
 #include <sunxi_def.h>
 #include <sunxi_mmap.h>
 
 #include "sunxi_private.h"
 
+static entry_point_info_t bl32_image_ep_info;
 static entry_point_info_t bl33_image_ep_info;
 
 static const gicv2_driver_data_t sunxi_gic_data = {
@@ -32,16 +34,26 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 		     SUNXI_UART0_CLK_IN_HZ,
 		     SUNXI_UART0_BAUDRATE);
 
+#ifdef BL32_BASE
+	/* Populate entry point information for BL32 */
+	SET_PARAM_HEAD(&bl32_image_ep_info, PARAM_EP, VERSION_1, 0);
+	SET_SECURITY_STATE(bl32_image_ep_info.h.attr, SECURE);
+	/* Tell BL32 where the trusted software image
+	 * is located and the entry state information
+	 */
+	bl32_image_ep_info.pc = BL32_BASE;
+	bl32_image_ep_info.spsr = arm_get_spsr_for_bl32_entry();
+#endif
 	/* Populate entry point information for BL33 */
 	SET_PARAM_HEAD(&bl33_image_ep_info, PARAM_EP, VERSION_1, 0);
+	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);
 	/*
 	 * Tell BL31 where the non-trusted software image
 	 * is located and the entry state information
 	 */
-	bl33_image_ep_info.pc = 0x4a000000;
+	bl33_image_ep_info.pc = PLAT_ARM_NS_IMAGE_OFFSET;
 	bl33_image_ep_info.spsr = SPSR_64(MODE_EL2, MODE_SP_ELX,
 					  DISABLE_ALL_EXCEPTIONS);
-	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);
 
 	/* Turn off all secondary CPUs */
 	sunxi_disable_secondary_cpus(plat_my_core_pos());
@@ -68,7 +80,12 @@ void bl31_platform_setup(void)
 entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 {
 	assert(sec_state_is_valid(type));
-	assert(type == NON_SECURE);
 
-	return &bl33_image_ep_info;
+	if (type == NON_SECURE)
+		return &bl33_image_ep_info;
+
+	else if (type == SECURE && bl32_image_ep_info.pc)
+		return &bl32_image_ep_info;
+
+	return NULL;
 }

--- a/plat/allwinner/sun50i_a64/platform.mk
+++ b/plat/allwinner/sun50i_a64/platform.mk
@@ -14,6 +14,7 @@ PLAT_INCLUDES		:=	-Iinclude/plat/arm/common/		\
 
 PLAT_BL_COMMON_SOURCES	:=	drivers/console/${ARCH}/console.S	\
 				drivers/ti/uart/${ARCH}/16550_console.S	\
+				plat/arm/common/arm_common.c \
 				${XLAT_TABLES_LIB_SRCS}			\
 				${AW_PLAT}/common/plat_helpers.S	\
 				${AW_PLAT}/common/sunxi_common.c


### PR DESCRIPTION
This patch is an attempt to run Trusted OS(OPTEE-OS being one of them) along
side BL31 image.

ATF supports multiple SPD's that can take dispatcher name(opteed for OPTEE-OS)
as an input using the 'SPD=<dispatcher name>' option during bl31 build.

Signed-off-by: Amit Singh Tomar <amittomer25@gmail.com>